### PR TITLE
Only sleep prior to retries

### DIFF
--- a/yas3fs/__init__.py
+++ b/yas3fs/__init__.py
@@ -2507,10 +2507,13 @@ class YAS3FS(LoggingMixIn, Operations):
                 logger.debug("read '%s' '%i' '%i' '%s' in range" % (path, length, offset, fh))
                 break
             else:
+                if retriesAttempted > 1:
+                    logger.debug('%d retries' % (retriesAttempted))
+                    time.sleep(self.read_retries_sleep)
+                
                 # Note added max retries as this can go on forever... for https://github.com/danilop/yas3fs/issues/46
                 logger.debug("read '%s' '%i' '%i' '%s' out of range" % (path, length, offset, fh))
                 self.enqueue_download_data(path, offset, length)
-                time.sleep(self.read_retries_sleep)
 
 
             logger.debug("read wait '%s' '%i' '%i' '%s'" % (path, length, offset, fh))


### PR DESCRIPTION
For quick enough downloads (that finish in under `self.read_retries_sleep`; 1s using the defaults), they'll complete before `data_range.wait()` is called (below), causing `wait()` to wait the full `io_wait` timeout (3s).

Rather than sleeping after all downloads are enqueued (prior to potential subsequent retries), sleep before attempting subsequent retries.  This dramatically speeds things up with smaller buffer sizes.
